### PR TITLE
Enhance input number filtering white space

### DIFF
--- a/src/NhsNumber.php
+++ b/src/NhsNumber.php
@@ -35,7 +35,7 @@ class NhsNumber
      */
     public function __construct($number)
     {
-        $this->number = (string) trim($number);
+        $this->number = str_replace(' ', '', $number);
     }
 
     /**


### PR DESCRIPTION
## Pull request type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [X] Bug fix (non-breaking change which fixes an issue)

## What does it change?

The `trim` function cannot filter white space correctly. Using the `str_replace` function instead.

## Why this PR?

To let input number be filtered white space correctly, create this PR to use the `str_replace` instead.

## How has this been tested?

Please consider following code snippets:

```php
Psy Shell v0.9.9 (PHP 7.1.30-1+ubuntu18.04.1+deb.sury.org+1 — cli) by Justin Hileman
>>> str_replace(' ', '', '1 2 3 4 5 6  7')
=> "1234567"
>>> trim('1 2 3 4 5 6  7')
=> "1 2 3 4 5 6  7"
>>> 

```
We can know that the `str_replace` function can filter white space correctly, and `trim` function cannot.