### PR TITLE
Remove unused param int comment annotation

### DIFF
--- a/src/NhsNumber.php
+++ b/src/NhsNumber.php
@@ -151,7 +151,6 @@ class NhsNumber
     /**
      * Generate a single random NHS number.
      *
-     * @param bool $unique
      * @return string
      */
     public static function getRandomNumber(): string


### PR DESCRIPTION
## Pull request type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)

## What does it change?

It seems that the `getRandomNumber` method doesn't have the parameters.

Removing the param comment annotation is necessary.

## Why this PR?

- Don't let people be confused for `getRandomNumber` method.

## How has this been tested?

This PR don't have any test.