### PR TITLE
Fix function name in readme file. Presumably in a former version the methods were `generateRandomNumber` and the readme was never changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ try {
 }
 ```
 
-To generate a single or multiple random valid NHS numbers for testing purposes, call the `::generateRandomNumber()` or `::generateRandomNumber($count)` static methods respectively.
+To generate a single or multiple random valid NHS numbers for testing purposes, call the `::getRandomNumber()` or `::getRandomNumbers($count)` static methods respectively.
 
 ```php
-echo \ImLiam\NhsNumber\NhsNumber::generateRandomNumber();
+echo \ImLiam\NhsNumber\NhsNumber::getRandomNumber();
 // '9278462608'
 
-echo \ImLiam\NhsNumber\NhsNumber::generateRandomNumbers(5);
+echo \ImLiam\NhsNumber\NhsNumber::getRandomNumbers(5);
 // ['7448556886', '0372104223', '8416367035']
 ```
 


### PR DESCRIPTION
## Pull request type

What kind of pull request is this? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Extend feature (non-breaking change which extends existing functionality)
- [ ] Change feature (non-breaking change which either changes or refactors existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Fix Typo

## What does it change?

Correct what we'll put down as a 'typo'

## Why this PR?

Solves about 10 minutes of confusion for people like me who found the repo and used it as per Readme doc, and wondered why the methods weren't working!

## How has this been tested?

Manually tested output


